### PR TITLE
Improved mod reporting, more mod support, small fixes.

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -2,6 +2,7 @@
 <LanguageData>
 
   <AM.ModTitle>Epicguru's Melee Animation</AM.ModTitle>
+  <AM.LoadingText>Loading Melee Animation</AM.LoadingText>
 
   <AM.Animation>Animation</AM.Animation>
 

--- a/Source/1.5/AnimationMod/AMSettings/Settings.cs
+++ b/Source/1.5/AnimationMod/AMSettings/Settings.cs
@@ -17,10 +17,17 @@ public class Settings : SimpleSettingsBase
     #region General
     [Header("General")]
     [Label("Always Animate Weapons")]
-    [Description("If enabled, melee weapons are animated whenever they are held, such as when standing drafted or while moving in combat.\nIf disabled, animations are limited to duels, special skills and executions.\n\n" +
+    [Description("If enabled, melee weapons are animated whenever they are held, such as when standing drafted, while moving in combat or while attacking.\nIf disabled, animations are limited to duels, special skills and executions.\n\n" +
                  "<b>Leaving this enabled can have a large performance impact on densely populated maps.\nPlease reload your save after changing this setting.</b>")]
     [WebContent("AlwaysAnimate", true)]
     public bool AnimateAtIdle = true;
+
+    [Label("Animations Use Body Posture")]
+    [Description("When enabled, simple animations (such as holding, walking and attacking with a melee weapon) will inherit body posture.\n" +
+        "This means that any other mods that modify pawn position, angle or size will also apply that change to the animated hands and weapon.\n" +
+        "Note: this does not apply to execution or duel animations, for technical reasons.")]
+    [VisibleIf(nameof(AnimateAtIdle))]
+    public bool InheritBodyPosture = true;
 
     [Label("Enable Unique Skills")]
     [Description("Enables or disables the Unique Skill system.\n" +

--- a/Source/1.5/AnimationMod/AnimationMod.csproj
+++ b/Source/1.5/AnimationMod/AnimationMod.csproj
@@ -52,5 +52,9 @@
     <OutputPath>..\..\..\$(RimworldVersion)\Assemblies\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="echo Build time is $([System.DateTime]::UtcNow.ToString(&quot;yyyyMMddHHmmss&quot;)). Assign this value in ModReportingFacade.cs and update the AWS API!" />
+  </Target>
 
 </Project>

--- a/Source/1.5/AnimationMod/Core.cs
+++ b/Source/1.5/AnimationMod/Core.cs
@@ -300,7 +300,6 @@ public class Core : Mod
         // Different thread loading...
         LongEventHandler.QueueLongEvent(() =>
         {
-            LongEventHandler.SetCurrentEventText("Load Advanced Animation Mod");
             while (lateLoadActions.TryDequeue(out var pair))
             {
                 try
@@ -313,7 +312,7 @@ public class Core : Mod
                     Error($"Exception in post-load event (async) '{pair.title}':", e);
                 }
             }
-        }, "Load Advanced Animation Mod", true, null);
+        }, "AM.LoadingText", true, null);
 
         // Same thread loading...
         LongEventHandler.QueueLongEvent(() =>
@@ -330,7 +329,7 @@ public class Core : Mod
                     Error($"Exception in post-load event '{pair.title}':", e);
                 }
             }
-        }, "Load Advanced Animation Mod", false, null);
+        }, "AM.LoadingText", false, null);
     }
 
     private void AddLateLoadAction(bool synchronous, string title, Action a)

--- a/Source/1.5/AnimationMod/Core.cs
+++ b/Source/1.5/AnimationMod/Core.cs
@@ -263,7 +263,7 @@ public class Core : Mod
                 ModID = p.Key,
                 ModName = p.Value.name,
                 WeaponCount = p.Value.wc,
-                MeleeAnimationBuildTimeUtc = modBuildTime
+                MeleeAnimationBuildTimeUtc = modBuildTime.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture)
             }));
 
             Task.Run(() => UploadMissingModData(toUpload)).ContinueWith(t =>

--- a/Source/1.5/AnimationMod/Core.cs
+++ b/Source/1.5/AnimationMod/Core.cs
@@ -263,7 +263,7 @@ public class Core : Mod
                 ModID = p.Key,
                 ModName = p.Value.name,
                 WeaponCount = p.Value.wc,
-                MeleeAnimationBuildTimeUtc = modBuildTime.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture)
+                ModBuildTimeUtc = modBuildTime
             }));
 
             Task.Run(() => UploadMissingModData(toUpload)).ContinueWith(t =>

--- a/Source/1.5/AnimationMod/Core.cs
+++ b/Source/1.5/AnimationMod/Core.cs
@@ -253,16 +253,19 @@ public class Core : Mod
             Warn($"{pair.Key} '{pair.Value.name}' has {pair.Value.wc} missing weapon tweak data.");
         }
 
-        var toUpload = new List<MissingModRequest>();
-        toUpload.AddRange(modsAndMissingWeaponCount.Select(p => new MissingModRequest
-        {
-            ModID = p.Key,
-            ModName = p.Value.name,
-            WeaponCount = p.Value.wc
-        }));
-
         if (Settings.SendStatistics && !Settings.IsFirstTimeRunning)
         {
+            var modBuildTime = GetBuildDate(Assembly.GetExecutingAssembly());
+
+            var toUpload = new List<MissingModRequest>();
+            toUpload.AddRange(modsAndMissingWeaponCount.Select(p => new MissingModRequest
+            {
+                ModID = p.Key,
+                ModName = p.Value.name,
+                WeaponCount = p.Value.wc,
+                MeleeAnimationBuildTimeUtc = modBuildTime
+            }));
+
             Task.Run(() => UploadMissingModData(toUpload)).ContinueWith(t =>
             {
                 if (t.IsCompletedSuccessfully)

--- a/Source/1.5/AnimationMod/Idle/IdleControllerComp.cs
+++ b/Source/1.5/AnimationMod/Idle/IdleControllerComp.cs
@@ -464,14 +464,26 @@ public class IdleControllerComp : ThingComp
 
     private Matrix4x4 MakePawnMatrix(Pawn pawn, bool north)
     {
-        var mat = Matrix4x4.TRS(pawn.DrawPos + new Vector3(0, north ? -0.8f : 0.1f), Quaternion.identity, Vector3.one);
+        var offset = new Vector3(0, north ? -0.8f : 0.1f, 0);
+
+        Matrix4x4 animationMatrix;
+        if (Core.Settings.InheritBodyPosture)
+        {
+            var currentDrawResults = pawn.drawer.renderer.results;
+            animationMatrix = currentDrawResults.parms.matrix * Matrix4x4.Translate(offset);
+        }
+        else
+        {
+            animationMatrix = Matrix4x4.TRS(pawn.DrawPos + offset, Quaternion.identity, Vector3.one);
+        }
+
         if (CurrentAnimation == null || !CurrentAnimation.Def.pointAtTarget)
-            return mat;
+            return animationMatrix;
 
         float frame = CurrentAnimation.CurrentTime * 60f;
         float lerp = Mathf.InverseLerp(CurrentAnimation.Def.returnToIdleStart, CurrentAnimation.Def.returnToIdleEnd, frame);
 
-        float idle = 0;
+        const float IDLE_ANGLE = 0;
         float point = -pauseAngle;
         if (CurrentAnimation.MirrorHorizontal)
         {
@@ -479,12 +491,16 @@ public class IdleControllerComp : ThingComp
         }
 
         if (CurrentAnimation.Def.idleType == IdleType.AttackNorth)
+        {
             point += 90;
-        if (CurrentAnimation.Def.idleType == IdleType.AttackSouth)
+        }
+        else if (CurrentAnimation.Def.idleType == IdleType.AttackSouth)
+        {
             point -= 90;
+        }
 
-        float a = Mathf.LerpAngle(point, idle, lerp);
-        return mat * Matrix4x4.Rotate(Quaternion.Euler(0f, a, 0f));
+        float a = Mathf.LerpAngle(point, IDLE_ANGLE, lerp);
+        return animationMatrix * Matrix4x4.Rotate(Quaternion.Euler(0f, a, 0f));
     }
 
     public override void PostDeSpawn(Map map)

--- a/Source/1.5/AnimationMod/Idle/IdleControllerComp.cs
+++ b/Source/1.5/AnimationMod/Idle/IdleControllerComp.cs
@@ -10,6 +10,7 @@ using RimWorld;
 using UnityEngine;
 using Verse;
 using LudeonTK;
+using System.Linq;
 
 namespace AM.Idle;
 
@@ -520,7 +521,7 @@ public class IdleControllerComp : ThingComp
             if (!ShouldHaveSkills())
                 return;
 
-            if (skills == null)
+            if (skills == null || skills.Any(s => s == null))
                 PopulateSkills();
 
             for (int i = 0; i < skills.Length; i++)

--- a/Source/1.5/ModRequestAPI.Backend/src/ModRequestAPI.Backend/Controllers/ModReportingController.cs
+++ b/Source/1.5/ModRequestAPI.Backend/src/ModRequestAPI.Backend/Controllers/ModReportingController.cs
@@ -2,36 +2,35 @@
 using ModRequestAPI.Backend.Facade;
 using ModRequestAPI.Models;
 
-namespace ModRequestAPI.Backend.Controllers
+namespace ModRequestAPI.Backend.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class ModReportingController : ControllerBase
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class ModReportingController : ControllerBase
+    private readonly ModReportingFacade facade;
+
+    public ModReportingController(ModReportingFacade facade)
     {
-        private readonly ModReportingFacade facade;
+        this.facade = facade;
+    }
 
-        public ModReportingController(ModReportingFacade facade)
-        {
-            this.facade = facade;
-        }
+    [HttpPost("report-missing-mods")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
+    public async Task<IActionResult> ReportMissingMod([FromBody] IEnumerable<MissingModRequest?> mods)
+    {
+        string? errorMsg = await facade.ReportMissingModAsync(mods);
+        if (errorMsg != null)
+            return BadRequest($"Error: {errorMsg}");
 
-        [HttpPost("report-missing-mods")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        public async Task<IActionResult> ReportMissingMod([FromBody] IEnumerable<MissingModRequest?> mods)
-        {
-            string? errorMsg = await facade.ReportMissingModAsync(mods);
-            if (errorMsg != null)
-                return BadRequest($"Error: {errorMsg}");
+        return Ok();
+    }
 
-            return Ok();
-        }
-
-        [HttpHead("health-check")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        public IActionResult HealthCheck()
-        {
-            return Ok();
-        }
+    [HttpHead("health-check")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult HealthCheck()
+    {
+        return Ok();
     }
 }

--- a/Source/1.5/ModRequestAPI.Backend/src/ModRequestAPI.Backend/Facade/ModReportingFacade.cs
+++ b/Source/1.5/ModRequestAPI.Backend/src/ModRequestAPI.Backend/Facade/ModReportingFacade.cs
@@ -39,15 +39,12 @@ public class ModReportingFacade
             if (req.ModName.Length > 64)
                 return "Mod name too long";
 
-            if (string.IsNullOrEmpty(req.MeleeAnimationBuildTimeUtc))
+            if (req.ModBuildTimeUtc == null)
                 return "Missing mod build time, probably very old version of Melee Animation submitting the request.";
 
-            if (!DateTime.TryParseExact(req.MeleeAnimationBuildTimeUtc, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTime))
-                return "Invalid mod build time.";
-
-            if (dateTime < currentBuildDate)
+            if (req.ModBuildTimeUtc.Value < currentBuildDate)
             {
-                TimeSpan delta = currentBuildDate - dateTime;
+                TimeSpan delta = currentBuildDate - req.ModBuildTimeUtc.Value;
                 TimeSpan deltaToNow = DateTime.UtcNow - currentBuildDate;
                 return "Your version of Melee Animation is not up to date, mod support request is rejected.\nPlease update to the latest version of the mod.\n" + 
                     $"Last Melee Animation mod update: {deltaToNow.TotalDays} days ago. Your mod version is {delta.TotalDays} days out of date.";

--- a/Source/1.5/ModRequestAPI.Backend/src/ModRequestAPI.Backend/Startup.cs
+++ b/Source/1.5/ModRequestAPI.Backend/src/ModRequestAPI.Backend/Startup.cs
@@ -2,55 +2,54 @@
 using ModRequestAPI.Backend.DAL;
 using ModRequestAPI.Backend.Facade;
 
-namespace ModRequestAPI.Backend
+namespace ModRequestAPI.Backend;
+
+public class Startup
 {
-    public class Startup
+    public IConfiguration Configuration { get; }
+
+    public Startup(IConfiguration configuration)
     {
-        public IConfiguration Configuration { get; }
+        Configuration = configuration;
+    }
 
-        public Startup(IConfiguration configuration)
+    // This method gets called by the runtime. Use this method to add services to the container
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllers();
+        services.AddSwaggerGen();
+
+        services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
+        services.AddDefaultAWSOptions(Configuration.GetAWSOptions());
+        services.AddAWSService<IAmazonDynamoDB>();
+
+        services.AddSingleton<ModReportingFacade>();
+        services.AddSingleton<ModReportingDAL>();
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
         {
-            Configuration = configuration;
-        }
+            app.UseDeveloperExceptionPage();
 
-        // This method gets called by the runtime. Use this method to add services to the container
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services.AddControllers();
-            services.AddSwaggerGen();
-
-            services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
-            services.AddDefaultAWSOptions(Configuration.GetAWSOptions());
-            services.AddAWSService<IAmazonDynamoDB>();
-
-            services.AddSingleton<ModReportingFacade>();
-            services.AddSingleton<ModReportingDAL>();
-        }
-
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
+            // Setup swagger:
+            app.UseSwagger();
+            app.UseSwaggerUI(op =>
             {
-                app.UseDeveloperExceptionPage();
-
-                // Setup swagger:
-                app.UseSwagger();
-                app.UseSwaggerUI(op =>
-                {
-                    op.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
-                    op.RoutePrefix = string.Empty;
-                });
-            }
-
-            app.UseHttpsRedirection();
-            app.UseRouting();
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
+                op.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
+                op.RoutePrefix = string.Empty;
             });
         }
+
+        app.UseHttpsRedirection();
+        app.UseRouting();
+        app.UseAuthorization();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapControllers();
+        });
     }
 }

--- a/Source/1.5/ModRequestAPI.Models/MissingModRequest.cs
+++ b/Source/1.5/ModRequestAPI.Models/MissingModRequest.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 
 namespace ModRequestAPI.Models
 {
@@ -27,6 +26,6 @@ namespace ModRequestAPI.Models
         /// The time and date, in UTC time, that the Melee Animation mod was built at.
         /// </summary>
         [JsonProperty("ModBuildTimeUtc")]
-        public DateTime? MeleeAnimationBuildTimeUtc { get; set; }
+        public string MeleeAnimationBuildTimeUtc { get; set; }
     }
 }

--- a/Source/1.5/ModRequestAPI.Models/MissingModRequest.cs
+++ b/Source/1.5/ModRequestAPI.Models/MissingModRequest.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace ModRequestAPI.Models
 {
@@ -26,6 +27,6 @@ namespace ModRequestAPI.Models
         /// The time and date, in UTC time, that the Melee Animation mod was built at.
         /// </summary>
         [JsonProperty("ModBuildTimeUtc")]
-        public string MeleeAnimationBuildTimeUtc { get; set; }
+        public DateTime? ModBuildTimeUtc { get; set; }
     }
 }

--- a/Source/1.5/ModRequestAPI.Models/MissingModRequest.cs
+++ b/Source/1.5/ModRequestAPI.Models/MissingModRequest.cs
@@ -1,8 +1,9 @@
 ﻿using Newtonsoft.Json;
+using System;
 
 namespace ModRequestAPI.Models
 {
-    public class MissingModRequest
+    public sealed class MissingModRequest
     {
         /// <summary>
         /// The ID of the mod that is missing weapons.
@@ -21,5 +22,11 @@ namespace ModRequestAPI.Models
         /// </summary>
         [JsonProperty("WeaponCount")]
         public int WeaponCount { get; set; }
+
+        /// <summary>
+        /// The time and date, in UTC time, that the Melee Animation mod was built at.
+        /// </summary>
+        [JsonProperty("ModBuildTimeUtc")]
+        public DateTime? MeleeAnimationBuildTimeUtc { get; set; }
     }
 }

--- a/WeaponTweakData/BM_Jackhammer_xmb.breadmech.json
+++ b/WeaponTweakData/BM_Jackhammer_xmb.breadmech.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "xmb.breadmech",
+  "ItemDefName": "BM_Jackhammer",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.399080217,
+  "OffY": -0.0374136269,
+  "ScaleX": 1.6,
+  "ScaleY": 1.6,
+  "BladeStart": 0.104134917,
+  "BladeEnd": 1.086246,
+  "MeleeWeaponType": 5
+}

--- a/WeaponTweakData/BM_Knife_xmb.breadmech.json
+++ b/WeaponTweakData/BM_Knife_xmb.breadmech.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "xmb.breadmech",
+  "ItemDefName": "BM_Knife",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.199539855,
+  "OffY": 0.00623574853,
+  "HandsMode": 1,
+  "BladeStart": 0.09789892,
+  "BladeEnd": 0.54998225,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/Beer_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/Beer_dankpyon.medieval.overhaul.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "Beer",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": -0.168361962,
+  "OffY": -0.01870668,
+  "FlipX": true,
+  "HandsMode": 1,
+  "BladeStart": 0.0615768656,
+  "BladeEnd": 0.3920648,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/BotchJob_FadingSoulScythe_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_FadingSoulScythe_botchjob.profaned.json
@@ -1,0 +1,20 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_FadingSoulScythe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4177872,
+  "OffY": -0.04988484,
+  "Rotation": 46.01165,
+  "ScaleX": 1.2,
+  "ScaleY": 1.2,
+  "BladeStart": 0.65084374,
+  "BladeEnd": 1.02809882,
+  "MeleeWeaponType": 2,
+  "TrailTint": {
+    "r": 0.234850973,
+    "g": 0.06287806,
+    "b": 0.4777779,
+    "a": 1.0
+  }
+}

--- a/WeaponTweakData/BotchJob_FrostboundGreataxe_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_FrostboundGreataxe_botchjob.profaned.json
@@ -1,0 +1,19 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_FrostboundGreataxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.205775857,
+  "Rotation": 90.0,
+  "ScaleX": 1.2,
+  "ScaleY": 1.2,
+  "BladeStart": 0.3452977,
+  "BladeEnd": 0.6539615,
+  "MeleeWeaponType": 6,
+  "TrailTint": {
+    "r": 0.372,
+    "g": 0.811,
+    "b": 0.964,
+    "a": 1.0
+  }
+}

--- a/WeaponTweakData/BotchJob_GraspingDeadGreatsword_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_GraspingDeadGreatsword_botchjob.profaned.json
@@ -1,0 +1,20 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_GraspingDeadGreatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.598620653,
+  "OffY": -0.0187069327,
+  "Rotation": 45.0,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.273588181,
+  "BladeEnd": 1.53630292,
+  "MeleeWeaponType": 6,
+  "TrailTint": {
+    "r": 0.166682884,
+    "g": 0.695061862,
+    "b": 0.108635649,
+    "a": 0.902
+  }
+}

--- a/WeaponTweakData/BotchJob_ProfanedClub_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_ProfanedClub_botchjob.profaned.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_ProfanedClub",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.243189216,
+  "OffY": 0.0187069178,
+  "ScaleX": 1.2,
+  "ScaleY": 1.2,
+  "BladeStart": 0.117697179,
+  "BladeEnd": 0.725671,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/BotchJob_ProfanedScimitar_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_ProfanedScimitar_botchjob.profaned.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_ProfanedScimitar",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.286838561,
+  "OffY": -0.00311774015,
+  "ScaleX": 1.3,
+  "ScaleY": 1.3,
+  "BladeStart": 0.117697179,
+  "BladeEnd": 0.894032955,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/BotchJob_ProfanedScythe_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_ProfanedScythe_botchjob.profaned.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_ProfanedScythe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.38660872,
+  "OffY": -0.0374136269,
+  "Rotation": 45.0,
+  "ScaleX": 1.2,
+  "ScaleY": 1.2,
+  "BladeStart": 0.613429844,
+  "BladeEnd": 0.975096166,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/BotchJob_ProfanedShotel_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_ProfanedShotel_botchjob.profaned.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_ProfanedShotel",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.286839128,
+  "OffY": -0.0155889392,
+  "ScaleX": 1.3,
+  "ScaleY": 1.3,
+  "BladeStart": 0.3203553,
+  "BladeEnd": 0.8909152,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/BotchJob_ProfanedWarAxe_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_ProfanedWarAxe_botchjob.profaned.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_ProfanedWarAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.2494252,
+  "OffY": -0.009353727,
+  "ScaleX": 1.2,
+  "ScaleY": 1.2,
+  "BladeStart": 0.3608869,
+  "BladeEnd": 0.753731132,
+  "MeleeWeaponType": 18
+}

--- a/WeaponTweakData/BotchJob_ScourgeknightGreataxe_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_ScourgeknightGreataxe_botchjob.profaned.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_ScourgeknightGreataxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.227600515,
+  "Rotation": 90.0,
+  "ScaleX": 1.2,
+  "ScaleY": 1.2,
+  "BladeStart": 0.3452977,
+  "BladeEnd": 0.66019696,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/BotchJob_ScourgeknightGreatsword_botchjob.profaned.json
+++ b/WeaponTweakData/BotchJob_ScourgeknightGreatsword_botchjob.profaned.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "botchjob.profaned",
+  "ItemDefName": "BotchJob_ScourgeknightGreatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.5393821,
+  "Rotation": 45.0,
+  "ScaleX": 1.2,
+  "ScaleY": 1.2,
+  "BladeStart": 0.2673522,
+  "BladeEnd": 1.35235178,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/DankPyon_Log_OE_DragonianWoodLog_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/DankPyon_Log_OE_DragonianWoodLog_dankpyon.medieval.overhaul.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "DankPyon_Log_OE_DragonianWoodLog",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.137183487,
+  "OffY": -0.06859177,
+  "Rotation": 41.90465,
+  "ScaleX": 0.75,
+  "ScaleY": 0.75,
+  "BladeEnd": 0.4159164,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/DankPyon_Log_OE_FungalWoodLog_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/DankPyon_Log_OE_FungalWoodLog_dankpyon.medieval.overhaul.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "DankPyon_Log_OE_FungalWoodLog",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.137183487,
+  "OffY": -0.06859177,
+  "Rotation": 41.90465,
+  "ScaleX": 0.75,
+  "ScaleY": 0.75,
+  "BladeEnd": 0.4159164,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/DankPyon_Log_RawDarkWood_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/DankPyon_Log_RawDarkWood_dankpyon.medieval.overhaul.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "DankPyon_Log_RawDarkWood",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.137183487,
+  "OffY": -0.06859177,
+  "Rotation": 41.90465,
+  "ScaleX": 0.75,
+  "ScaleY": 0.75,
+  "BladeEnd": 0.4159164,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/DankPyon_Wine_Griffon_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/DankPyon_Wine_Griffon_dankpyon.medieval.overhaul.json
@@ -1,0 +1,15 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "DankPyon_Wine_Griffon",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.205775827,
+  "OffY": -0.00623548031,
+  "Rotation": -90.0,
+  "ScaleX": 0.8,
+  "ScaleY": 0.8,
+  "HandsMode": 1,
+  "BladeStart": 0.0386608765,
+  "BladeEnd": 0.534393,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/DankPyon_Wine_Ice_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/DankPyon_Wine_Ice_dankpyon.medieval.overhaul.json
@@ -1,0 +1,15 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "DankPyon_Wine_Ice",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.205775827,
+  "OffY": -0.00623548031,
+  "Rotation": -90.0,
+  "ScaleX": 0.8,
+  "ScaleY": 0.8,
+  "HandsMode": 1,
+  "BladeStart": 0.0386608765,
+  "BladeEnd": 0.534393,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/GU_RedWood_sarg.alphamemes.json
+++ b/WeaponTweakData/GU_RedWood_sarg.alphamemes.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "sarg.alphamemes",
+  "ItemDefName": "GU_RedWood",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.106005132,
+  "OffY": -0.02182468,
+  "Rotation": 40.0,
+  "ScaleX": 0.8,
+  "ScaleY": 0.8,
+  "BladeEnd": 0.3286172,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Dagger_doublec.skyrimdaedricweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Dagger_doublec.skyrimdaedricweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimdaedricweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Daedric_Dagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.1808334,
+  "OffY": -0.0405316353,
+  "ScaleY": 0.8,
+  "BladeStart": 0.09275476,
+  "BladeEnd": 0.622783065,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Greatsword_doublec.skyrimdaedricweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Greatsword_doublec.skyrimdaedricweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdaedricweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Daedric_Greatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.486378968,
+  "OffY": -0.00935351849,
+  "ScaleX": 1.5,
+  "ScaleY": 1.1,
+  "BladeStart": 0.136404127,
+  "BladeEnd": 1.2525816,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Mace_doublec.skyrimdaedricweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Mace_doublec.skyrimdaedricweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdaedricweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Daedric_Mace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.2244828,
+  "OffY": -0.0124712586,
+  "ScaleX": 1.1,
+  "ScaleY": 0.8,
+  "BladeStart": 0.19252494,
+  "BladeEnd": 0.710081756,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Sword_doublec.skyrimdaedricweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Sword_doublec.skyrimdaedricweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdaedricweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Daedric_Sword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.439611852,
+  "OffY": -0.0530028343,
+  "ScaleX": 1.5,
+  "ScaleY": 1.1,
+  "BladeStart": 0.186288953,
+  "BladeEnd": 1.20893216,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Waraxe_doublec.skyrimdaedricweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Waraxe_doublec.skyrimdaedricweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdaedricweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Daedric_WarAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.330488443,
+  "OffY": -0.0467671,
+  "ScaleX": 1.3,
+  "ScaleY": 0.8,
+  "BladeStart": 0.420125484,
+  "BladeEnd": 0.9439178,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Warhammeraxe_doublec.skyrimdaedricweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Daedric_Warhammeraxe_doublec.skyrimdaedricweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdaedricweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Daedric_Warhammeraxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.3585486,
+  "OffY": -0.046767354,
+  "Rotation": -1.460185,
+  "ScaleX": 1.5,
+  "BladeStart": 0.7319065,
+  "BladeEnd": 1.05615938,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Dagger_doublec.skyrimdragonboneweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Dagger_doublec.skyrimdragonboneweaponspack.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "doublec.skyrimdragonboneweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dragonbone_Dagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.243189752,
+  "OffY": -0.00935322,
+  "ScaleX": 1.1,
+  "ScaleY": 0.8,
+  "HandsMode": 1,
+  "BladeStart": 0.136404127,
+  "BladeEnd": 0.6352545,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Greatsword_doublec.skyrimdragonboneweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Greatsword_doublec.skyrimdragonboneweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimdragonboneweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dragonbone_Greatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.489496678,
+  "ScaleX": 1.6,
+  "ScaleY": 1.1,
+  "BladeStart": 0.167582527,
+  "BladeEnd": 1.23699236,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Mace_doublec.skyrimdragonboneweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Mace_doublec.skyrimdragonboneweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdragonboneweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dragonbone_Mace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.19330439,
+  "OffY": -0.009353474,
+  "ScaleX": 0.9,
+  "ScaleY": 0.8,
+  "BladeStart": 0.0459876619,
+  "BladeEnd": 0.6165476,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Sword_doublec.skyrimdragonboneweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Sword_doublec.skyrimdragonboneweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimdragonboneweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dragonbone_Sword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.3897265,
+  "OffY": -0.0218246877,
+  "ScaleX": 1.2,
+  "BladeStart": 0.120814919,
+  "BladeEnd": 0.937682331,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Waraxe_doublec.skyrimdragonboneweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Waraxe_doublec.skyrimdragonboneweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdragonboneweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dragonbone_WarAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.1340658,
+  "OffY": 0.009353459,
+  "ScaleX": 1.05,
+  "ScaleY": 0.8,
+  "BladeStart": 0.279823661,
+  "BladeEnd": 0.5292489,
+  "MeleeWeaponType": 18
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Warhammeraxe_doublec.skyrimdragonboneweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dragonbone_Warhammeraxe_doublec.skyrimdragonboneweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimdragonboneweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dragonbone_Warhammeraxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.433376372,
+  "OffY": -0.012471199,
+  "ScaleX": 1.5,
+  "BladeStart": 0.3920648,
+  "BladeEnd": 1.12163353,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Dagger_doublec.skyrimdwarvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Dagger_doublec.skyrimdwarvenweaponspack.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "doublec.skyrimdwarvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dwarven_Dagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.208893582,
+  "OffY": -0.0124714673,
+  "ScaleX": 0.7,
+  "ScaleY": 0.55,
+  "HandsMode": 1,
+  "BladeStart": 0.102107972,
+  "BladeEnd": 0.526131153,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Greatsword_doublec.skyrimdwarvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Greatsword_doublec.skyrimdwarvenweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdwarvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dwarven_Greatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4957322,
+  "OffY": -0.00311774015,
+  "ScaleX": 1.6,
+  "ScaleY": 1.1,
+  "BladeStart": 0.163529158,
+  "BladeEnd": 1.2547642,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Mace_doublec.skyrimdwarvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Mace_doublec.skyrimdwarvenweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdwarvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dwarven_Mace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.255660683,
+  "OffY": -0.0155889392,
+  "ScaleX": 1.1,
+  "ScaleY": 0.9,
+  "BladeStart": 0.3537158,
+  "BladeEnd": 0.7652675,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Sword_doublec.skyrimdwarvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Sword_doublec.skyrimdwarvenweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimdwarvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dwarven_Sword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4458473,
+  "OffY": -0.009353727,
+  "ScaleX": 1.3,
+  "BladeStart": 0.1042906,
+  "BladeEnd": 1.0832845,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Waraxe_doublec.skyrimdwarvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Waraxe_doublec.skyrimdwarvenweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimdwarvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dwarven_WarAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.230718255,
+  "OffY": -0.04364936,
+  "ScaleX": 1.1,
+  "ScaleY": 0.7,
+  "BladeStart": 0.3069487,
+  "BladeEnd": 0.7184999,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Warhammeraxe_doublec.skyrimdwarvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Dwarven_Warhammeraxe_doublec.skyrimdwarvenweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimdwarvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Dwarven_Warhammeraxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.402197957,
+  "OffY": -0.009353474,
+  "ScaleX": 1.5,
+  "BladeStart": 0.3069487,
+  "BladeEnd": 1.15187621,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Dagger_doublec.skyrimebonyweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Dagger_doublec.skyrimebonyweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimebonyweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Ebony_Dagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.19018665,
+  "OffY": -0.0155889392,
+  "ScaleX": 0.8,
+  "ScaleY": 0.55,
+  "HandsMode": 1,
+  "BladeStart": 0.08028329,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Greatsword_doublec.skyrimebonyweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Greatsword_doublec.skyrimebonyweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimebonyweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Ebony_Greatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.424022645,
+  "OffY": 0.0187069178,
+  "ScaleX": 1.5,
+  "ScaleY": 1.1,
+  "BladeStart": 0.20187816,
+  "BladeEnd": 1.14969361,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Mace_doublec.skyrimebonyweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Mace_doublec.skyrimebonyweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimebonyweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Ebony_Mace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.2525429,
+  "OffY": -0.012471199,
+  "ScaleX": 1.1,
+  "ScaleY": 0.8,
+  "BladeStart": 0.364004642,
+  "BladeEnd": 0.7007286,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Sword_doublec.skyrimebonyweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Sword_doublec.skyrimebonyweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimebonyweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Ebony_Sword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.371020049,
+  "OffY": -0.00935322,
+  "ScaleX": 1.4,
+  "ScaleY": 0.95,
+  "BladeStart": 0.173818,
+  "BladeEnd": 1.06239486,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Waraxe_doublec.skyrimebonyweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Waraxe_doublec.skyrimebonyweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimebonyweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Ebony_WarAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.246306956,
+  "OffY": 0.0436496139,
+  "ScaleX": 1.3,
+  "ScaleY": 0.8,
+  "BladeStart": 0.370240122,
+  "BladeEnd": 0.831676662,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Warhammeraxe_doublec.skyrimebonyweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Ebony_Warhammeraxe_doublec.skyrimebonyweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimebonyweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Ebony_Warhammeraxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.2806031,
+  "OffY": -0.0374136567,
+  "ScaleX": 1.5,
+  "BladeStart": 0.485599518,
+  "BladeEnd": 0.9844494,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Dagger_doublec.skyrimelvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Dagger_doublec.skyrimelvenweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimelvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Elven_Dagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.187068373,
+  "OffY": -0.00623548031,
+  "ScaleX": 0.7,
+  "ScaleY": 0.55,
+  "HandsMode": 1,
+  "BladeStart": 0.105226226,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Greatsword_doublec.skyrimelvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Greatsword_doublec.skyrimelvenweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimelvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Elven_Greatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.439611822,
+  "ScaleX": 1.5,
+  "ScaleY": 1.1,
+  "BladeStart": 0.19252494,
+  "BladeEnd": 1.18398976,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Mace_doublec.skyrimelvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Mace_doublec.skyrimelvenweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimelvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Elven_Mace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.196422115,
+  "OffY": -0.0187069178,
+  "ScaleY": 0.8,
+  "BladeStart": 0.373357862,
+  "BladeEnd": 0.66643244,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Sword_doublec.skyrimelvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Sword_doublec.skyrimelvenweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimelvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Elven_Sword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.439611852,
+  "ScaleX": 1.3,
+  "ScaleY": 0.95,
+  "BladeStart": 0.145757854,
+  "BladeEnd": 1.04680574,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Waraxe_doublec.skyrimelvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Waraxe_doublec.skyrimelvenweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimelvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Elven_WarAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.22760053,
+  "OffY": -0.137183785,
+  "ScaleX": 1.2,
+  "ScaleY": 0.8,
+  "BladeStart": 0.23305656,
+  "BladeEnd": 0.7662026,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Warhammeraxe_doublec.skyrimelvenweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Elven_Warhammeraxe_doublec.skyrimelvenweaponspack.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "doublec.skyrimelvenweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Elven_Warhammeraxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.308663756,
+  "ScaleX": 1.5,
+  "BladeStart": 0.3297085,
+  "BladeEnd": 0.993803144,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Dagger_doublec.skyrimglassweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Dagger_doublec.skyrimglassweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimglassweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Glass_Dagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.1964221,
+  "ScaleX": 0.8,
+  "ScaleY": 0.55,
+  "HandsMode": 1,
+  "BladeStart": 0.09899024,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Greatsword_doublec.skyrimglassweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Greatsword_doublec.skyrimglassweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimglassweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Glass_Greatsword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.427140355,
+  "ScaleX": 1.5,
+  "ScaleY": 1.1,
+  "BladeStart": 0.1270509,
+  "BladeEnd": 1.13098669,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Mace_doublec.skyrimglassweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Mace_doublec.skyrimglassweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimglassweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Glass_Mace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.196422115,
+  "ScaleX": 1.1,
+  "ScaleY": 0.8,
+  "BladeStart": 0.348415434,
+  "BladeEnd": 0.691374838,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Sword_doublec.skyrimglassweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Sword_doublec.skyrimglassweaponspack.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "doublec.skyrimglassweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Glass_Sword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4302581,
+  "ScaleX": 1.4,
+  "ScaleY": 0.95,
+  "BladeStart": 0.123933166,
+  "BladeEnd": 1.090455,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Waraxe_doublec.skyrimglassweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Waraxe_doublec.skyrimglassweaponspack.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "doublec.skyrimglassweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Glass_WarAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.277485371,
+  "OffY": -0.009353459,
+  "ScaleX": 1.3,
+  "ScaleY": 0.8,
+  "BladeStart": 0.286059141,
+  "BladeEnd": 0.8877975,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Warhammeraxe_doublec.skyrimglassweaponspack.json
+++ b/WeaponTweakData/MeleeWeapon_Skyrim_Glass_Warhammeraxe_doublec.skyrimglassweaponspack.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "doublec.skyrimglassweaponspack",
+  "ItemDefName": "MeleeWeapon_Skyrim_Glass_Warhammeraxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.305545539,
+  "ScaleX": 1.5,
+  "BladeStart": 0.7350242,
+  "BladeEnd": 1.0031563,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/ODC_Rapier_P_Acid_obsidiaexpansion.core.json
+++ b/WeaponTweakData/ODC_Rapier_P_Acid_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "ODC_Rapier_P_Acid",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.336723924,
+  "OffY": -0.04988535,
+  "BladeStart": 0.152149,
+  "BladeEnd": 0.8131259,
+  "MeleeWeaponType": 4
+}

--- a/WeaponTweakData/ODC_Rapier_P_Cryo_obsidiaexpansion.core.json
+++ b/WeaponTweakData/ODC_Rapier_P_Cryo_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "ODC_Rapier_P_Cryo",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.336723924,
+  "OffY": -0.04988535,
+  "BladeStart": 0.152149,
+  "BladeEnd": 0.8131259,
+  "MeleeWeaponType": 4
+}

--- a/WeaponTweakData/ODC_Rapier_P_EMP_obsidiaexpansion.core.json
+++ b/WeaponTweakData/ODC_Rapier_P_EMP_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "ODC_Rapier_P_EMP",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.336723924,
+  "OffY": -0.04988535,
+  "BladeStart": 0.152149,
+  "BladeEnd": 0.8131259,
+  "MeleeWeaponType": 4
+}

--- a/WeaponTweakData/ODC_Rapier_P_Fire_obsidiaexpansion.core.json
+++ b/WeaponTweakData/ODC_Rapier_P_Fire_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "ODC_Rapier_P_Fire",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.336723924,
+  "OffY": -0.04988535,
+  "BladeStart": 0.152149,
+  "BladeEnd": 0.8131259,
+  "MeleeWeaponType": 4
+}

--- a/WeaponTweakData/ODC_Trophy_Sickle_A_obsidiaexpansion.core.json
+++ b/WeaponTweakData/ODC_Trophy_Sickle_A_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "ODC_Trophy_Sickle_A",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.299310029,
+  "OffY": -0.0374138877,
+  "BladeStart": 0.07108576,
+  "BladeEnd": 0.747651339,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ODC_Trophy_Sickle_B_obsidiaexpansion.core.json
+++ b/WeaponTweakData/ODC_Trophy_Sickle_B_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "ODC_Trophy_Sickle_B",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.299310029,
+  "OffY": -0.0374138877,
+  "BladeStart": 0.07108576,
+  "BladeEnd": 0.747651339,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ODC_Trophy_Sickle_C_obsidiaexpansion.core.json
+++ b/WeaponTweakData/ODC_Trophy_Sickle_C_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "ODC_Trophy_Sickle_C",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.299310029,
+  "OffY": -0.0374138877,
+  "BladeStart": 0.07108576,
+  "BladeEnd": 0.747651339,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/OE_DragonianWoodLog_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/OE_DragonianWoodLog_dankpyon.medieval.overhaul.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "OE_DragonianWoodLog",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.177024722,
+  "OffY": -0.05649717,
+  "Rotation": 45.0,
+  "ScaleX": 0.8,
+  "ScaleY": 0.8,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/OE_FungalWoodLog_dankpyon.medieval.overhaul.json
+++ b/WeaponTweakData/OE_FungalWoodLog_dankpyon.medieval.overhaul.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "dankpyon.medieval.overhaul",
+  "ItemDefName": "OE_FungalWoodLog",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.177024722,
+  "OffY": -0.05649717,
+  "Rotation": 45.0,
+  "ScaleX": 0.8,
+  "ScaleY": 0.8,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/OTC_ChainAxe_Acid_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_Acid_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_Acid",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_ChainAxe_Cryo_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_Cryo_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_Cryo",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_ChainAxe_EMP_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_EMP_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_EMP",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_ChainAxe_Fire_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_Fire_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_Fire",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_ChainAxe_M_Acid_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_M_Acid_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_M_Acid",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_ChainAxe_M_Cryo_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_M_Cryo_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_M_Cryo",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_ChainAxe_M_EMP_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_M_EMP_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_M_EMP",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_ChainAxe_M_Fire_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_ChainAxe_M_Fire_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_ChainAxe_M_Fire",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.134065837,
+  "OffY": -0.06859176,
+  "Rotation": -1.323526,
+  "BladeStart": 0.03990787,
+  "BladeEnd": 0.367278069,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/OTC_Hammer_Acid_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Hammer_Acid_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Hammer_Acid",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.119449995,
+  "OffY": -0.059724763,
+  "HandsMode": 1,
+  "BladeStart": 0.150884181,
+  "BladeEnd": 0.37721023,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/OTC_Hammer_P_Acid_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Hammer_P_Acid_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Hammer_P_Acid",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.119449995,
+  "OffY": -0.059724763,
+  "HandsMode": 1,
+  "BladeStart": 0.150884181,
+  "BladeEnd": 0.37721023,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/OTC_Hammer_P_Cryo_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Hammer_P_Cryo_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Hammer_P_Cryo",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.119449995,
+  "OffY": -0.059724763,
+  "HandsMode": 1,
+  "BladeStart": 0.150884181,
+  "BladeEnd": 0.37721023,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/OTC_Hammer_P_EMP_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Hammer_P_EMP_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Hammer_P_EMP",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.119449995,
+  "OffY": -0.059724763,
+  "HandsMode": 1,
+  "BladeStart": 0.150884181,
+  "BladeEnd": 0.37721023,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/OTC_Hammer_P_Fire_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Hammer_P_Fire_obsidiaexpansion.core.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Hammer_P_Fire",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.119449995,
+  "OffY": -0.059724763,
+  "HandsMode": 1,
+  "BladeStart": 0.150884181,
+  "BladeEnd": 0.37721023,
+  "MeleeWeaponType": 8
+}

--- a/WeaponTweakData/OTC_Trophy_Sword_Acid_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Trophy_Sword_Acid_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Trophy_Sword_Acid",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.236953735,
+  "OffY": -0.0155892046,
+  "BladeStart": 0.0866749659,
+  "BladeEnd": 0.6385279,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/OTC_Trophy_Sword_Cryo_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Trophy_Sword_Cryo_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Trophy_Sword_Cryo",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.236953735,
+  "OffY": -0.0155892046,
+  "BladeStart": 0.0866749659,
+  "BladeEnd": 0.6385279,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/OTC_Trophy_Sword_EMP_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Trophy_Sword_EMP_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Trophy_Sword_EMP",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.236953735,
+  "OffY": -0.0155892046,
+  "BladeStart": 0.0866749659,
+  "BladeEnd": 0.6385279,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/OTC_Trophy_Sword_Fire_obsidiaexpansion.core.json
+++ b/WeaponTweakData/OTC_Trophy_Sword_Fire_obsidiaexpansion.core.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "obsidiaexpansion.core",
+  "ItemDefName": "OTC_Trophy_Sword_Fire",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.236953735,
+  "OffY": -0.0155892046,
+  "BladeStart": 0.0866749659,
+  "BladeEnd": 0.6385279,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/PJ_StaffX_projectjedi.factions.json
+++ b/WeaponTweakData/PJ_StaffX_projectjedi.factions.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "projectjedi.factions",
+  "ItemDefName": "PJ_StaffX",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "Rotation": 25.0,
+  "ScaleX": 2.3,
+  "ScaleY": 2.3,
+  "BladeStart": -1.19178462,
+  "BladeEnd": 1.24011,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/PJ_TStaff_projectjedi.factions.json
+++ b/WeaponTweakData/PJ_TStaff_projectjedi.factions.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "projectjedi.factions",
+  "ItemDefName": "PJ_TStaff",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "Rotation": 46.29958,
+  "ScaleX": 2.3,
+  "ScaleY": 2.3,
+  "BladeStart": -1.49733019,
+  "BladeEnd": 1.43341494,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/PJ_VScythe_projectjedi.factions.json
+++ b/WeaponTweakData/PJ_VScythe_projectjedi.factions.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "projectjedi.factions",
+  "ItemDefName": "PJ_VScythe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.2587784,
+  "OffY": -0.0187069476,
+  "Rotation": 90.0,
+  "ScaleX": 1.3,
+  "ScaleY": 1.3,
+  "BladeStart": -0.26267612,
+  "BladeEnd": 0.8347944,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/PJ_Vibroaxe_projectjedi.factions.json
+++ b/WeaponTweakData/PJ_Vibroaxe_projectjedi.factions.json
@@ -1,0 +1,15 @@
+{
+  "TextureModID": "projectjedi.factions",
+  "ItemDefName": "PJ_Vibroaxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": -0.639152169,
+  "OffY": 0.0530030876,
+  "Rotation": 2.916248,
+  "ScaleX": 2.3,
+  "ScaleY": 2.3,
+  "FlipX": true,
+  "BladeStart": 1.18087208,
+  "BladeEnd": 1.72648954,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/PJ_Vibrocleaver_projectjedi.factions.json
+++ b/WeaponTweakData/PJ_Vibrocleaver_projectjedi.factions.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "projectjedi.factions",
+  "ItemDefName": "PJ_Vibrocleaver",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4177872,
+  "OffY": 0.0779455,
+  "Rotation": 45.0,
+  "ScaleX": 1.6,
+  "ScaleY": 1.6,
+  "BladeStart": 0.3047661,
+  "BladeEnd": 1.05927718,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/PJ_Vibrodouble_projectjedi.factions.json
+++ b/WeaponTweakData/PJ_Vibrodouble_projectjedi.factions.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "projectjedi.factions",
+  "ItemDefName": "PJ_Vibrodouble",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "ScaleX": 2.3,
+  "ScaleY": 2.3,
+  "FlipY": true,
+  "BladeStart": -1.10136819,
+  "BladeEnd": 1.09357333,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/PJ_Vibrosword_projectjedi.factions.json
+++ b/WeaponTweakData/PJ_Vibrosword_projectjedi.factions.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "projectjedi.factions",
+  "ItemDefName": "PJ_Vibrosword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.299310029,
+  "OffY": -0.09665245,
+  "Rotation": 38.95255,
+  "ScaleX": 1.5,
+  "ScaleY": 1.5,
+  "BladeStart": 0.1894072,
+  "BladeEnd": 1.31493783,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/RHMelee_StunRod_rh2.faction.militaires.sans.frontieres.json
+++ b/WeaponTweakData/RHMelee_StunRod_rh2.faction.militaires.sans.frontieres.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "rh2.faction.militaires.sans.frontieres",
+  "ItemDefName": "RHMelee_StunRod",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.3554314,
+  "OffY": -0.009353474,
+  "Rotation": 45.0,
+  "BladeStart": 0.16446428,
+  "BladeEnd": 0.8347944,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/RNMeleeWeapon_Manganese_Wakizashi_cp.rimmunation.2.weapons.json
+++ b/WeaponTweakData/RNMeleeWeapon_Manganese_Wakizashi_cp.rimmunation.2.weapons.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "cp.rimmunation.2.weapons",
+  "ItemDefName": "RNMeleeWeapon_Manganese_Wakizashi",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4427296,
+  "Rotation": 45.0,
+  "BladeStart": 0.11037039,
+  "BladeEnd": 0.924120069,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ReviaBlessedSerratedDagger_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaBlessedSerratedDagger_fs.reviaracebiotech.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaBlessedSerratedDagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.199540377,
+  "OffY": -0.00623573363,
+  "ScaleX": 0.6,
+  "ScaleY": 0.6,
+  "HandsMode": 1,
+  "BladeStart": 0.09275476,
+  "BladeEnd": 0.407654017,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/ReviaBlessedSerratedScythe_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaBlessedSerratedScythe_fs.reviaracebiotech.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaBlessedSerratedScythe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.523792863,
+  "OffY": -0.06547403,
+  "Rotation": 46.19223,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.7131995,
+  "BladeEnd": 1.32117331,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ReviaBlessedSerratedSword_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaBlessedSerratedSword_fs.reviaracebiotech.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaBlessedSerratedSword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.299310029,
+  "OffY": -0.0311784148,
+  "Rotation": 3.95037,
+  "BladeStart": 0.0459876619,
+  "BladeEnd": 0.7443779,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ReviaChainSword_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaChainSword_fs.reviaracebiotech.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaChainSword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.3336057,
+  "OffY": -0.00623574853,
+  "BladeStart": 0.0958725,
+  "BladeEnd": 0.8067342,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ReviaSerratedDagger_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaSerratedDagger_fs.reviaracebiotech.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaSerratedDagger",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.199540377,
+  "OffY": -0.00623573363,
+  "ScaleX": 0.6,
+  "ScaleY": 0.6,
+  "HandsMode": 1,
+  "BladeStart": 0.09275476,
+  "BladeEnd": 0.407654017,
+  "MeleeWeaponType": 48
+}

--- a/WeaponTweakData/ReviaSerratedScythe_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaSerratedScythe_fs.reviaracebiotech.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaSerratedScythe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.523792863,
+  "OffY": -0.06547403,
+  "Rotation": 46.19223,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.7131995,
+  "BladeEnd": 1.32117331,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ReviaSerratedSword_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaSerratedSword_fs.reviaracebiotech.json
@@ -1,0 +1,12 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaSerratedSword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.299310029,
+  "OffY": -0.0311784148,
+  "Rotation": 3.95037,
+  "BladeStart": 0.0459876619,
+  "BladeEnd": 0.7443779,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/ReviaWarPick_fs.reviaracebiotech.json
+++ b/WeaponTweakData/ReviaWarPick_fs.reviaracebiotech.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "fs.reviaracebiotech",
+  "ItemDefName": "ReviaWarPick",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.5082036,
+  "OffY": 0.01870694,
+  "Rotation": 50.0,
+  "ScaleX": 1.5,
+  "ScaleY": 1.5,
+  "BladeStart": 0.7817918,
+  "BladeEnd": 0.981331646,
+  "MeleeWeaponType": 3
+}

--- a/WeaponTweakData/botchjob.profaned.txt
+++ b/WeaponTweakData/botchjob.profaned.txt
@@ -1,0 +1,1 @@
+The Profaned

--- a/WeaponTweakData/doublec.skyrimdaedricweaponspack.txt
+++ b/WeaponTweakData/doublec.skyrimdaedricweaponspack.txt
@@ -1,0 +1,1 @@
+Skyrim Daedric Weapons Pack

--- a/WeaponTweakData/doublec.skyrimdragonboneweaponspack.txt
+++ b/WeaponTweakData/doublec.skyrimdragonboneweaponspack.txt
@@ -1,0 +1,1 @@
+Skyrim Dragonbone Weapons Pack

--- a/WeaponTweakData/doublec.skyrimdwarvenweaponspack.txt
+++ b/WeaponTweakData/doublec.skyrimdwarvenweaponspack.txt
@@ -1,0 +1,1 @@
+Skyrim Dwarven Weapons Pack

--- a/WeaponTweakData/doublec.skyrimebonyweaponspack.txt
+++ b/WeaponTweakData/doublec.skyrimebonyweaponspack.txt
@@ -1,0 +1,1 @@
+Skyrim Ebony Weapons Pack

--- a/WeaponTweakData/doublec.skyrimelvenweaponspack.txt
+++ b/WeaponTweakData/doublec.skyrimelvenweaponspack.txt
@@ -1,0 +1,1 @@
+Skyrim Elven Weapons Pack

--- a/WeaponTweakData/doublec.skyrimglassweaponspack.txt
+++ b/WeaponTweakData/doublec.skyrimglassweaponspack.txt
@@ -1,0 +1,1 @@
+Skyrim Glass Weapons Pack

--- a/WeaponTweakData/fs.reviaracebiotech.txt
+++ b/WeaponTweakData/fs.reviaracebiotech.txt
@@ -1,0 +1,1 @@
+Revia Race - biotech

--- a/WeaponTweakData/pphhyy.barbariansmosubmod.txt
+++ b/WeaponTweakData/pphhyy.barbariansmosubmod.txt
@@ -1,0 +1,1 @@
+Medieval Overhaul: Barbarians

--- a/WeaponTweakData/pphhyy_Barbarian_BoneClub_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_BoneClub_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_BoneClub",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.215129063,
+  "OffY": -0.0218246579,
+  "BladeStart": 0.0834015459,
+  "BladeEnd": 0.675786138,
+  "MeleeWeaponType": 9
+}

--- a/WeaponTweakData/pphhyy_Barbarian_ClawClub_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_ClawClub_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_ClawClub",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.22760053,
+  "OffY": -0.0530028343,
+  "BladeStart": 0.08028329,
+  "BladeEnd": 0.6944931,
+  "MeleeWeaponType": 25
+}

--- a/WeaponTweakData/pphhyy_Barbarian_GreatBoneClub_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_GreatBoneClub_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_GreatBoneClub",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4209049,
+  "OffY": 0.012471199,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.498070449,
+  "BladeEnd": 1.10604429,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/pphhyy_Barbarian_GreatSkullMace_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_GreatSkullMace_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_GreatSkullMace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.424022645,
+  "OffY": -0.0249426961,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.6071939,
+  "BladeEnd": 0.9688607,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedAxe_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedAxe_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.246306956,
+  "OffY": -0.08106324,
+  "BladeStart": 0.3920648,
+  "BladeEnd": 0.738142431,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedBattleAxe_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedBattleAxe_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedBattleAxe",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.330487967,
+  "OffY": -0.0342958868,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.488717258,
+  "BladeEnd": 0.9626247,
+  "MeleeWeaponType": 2
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedClaymore_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedClaymore_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedClaymore",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.492614955,
+  "OffY": -0.0810627341,
+  "ScaleX": 1.5,
+  "ScaleY": 1.5,
+  "BladeStart": 0.130168647,
+  "BladeEnd": 1.20581448,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedGlaive_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedGlaive_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,13 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedGlaive",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.4209049,
+  "OffY": -0.0249426961,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.451303363,
+  "BladeEnd": 1.096691,
+  "MeleeWeaponType": 6
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedGreatSkullMace_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedGreatSkullMace_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,14 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedGreatSkullMace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.38972643,
+  "OffY": -0.006235212,
+  "Rotation": -1.250388,
+  "ScaleX": 1.4,
+  "ScaleY": 1.4,
+  "BladeStart": 0.5822514,
+  "BladeEnd": 0.9719784,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedMace_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedMace_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedMace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.208893061,
+  "OffY": -0.012471199,
+  "BladeStart": 0.473128051,
+  "BladeEnd": 0.6726684,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedSkullMace_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedSkullMace_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedSkullMace",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.23071827,
+  "OffY": -0.009353459,
+  "BladeStart": 0.3764756,
+  "BladeEnd": 0.6789039,
+  "MeleeWeaponType": 1
+}

--- a/WeaponTweakData/pphhyy_Barbarian_RustedSword_pphhyy.barbariansmosubmod.json
+++ b/WeaponTweakData/pphhyy_Barbarian_RustedSword_pphhyy.barbariansmosubmod.json
@@ -1,0 +1,11 @@
+{
+  "TextureModID": "pphhyy.barbariansmosubmod",
+  "ItemDefName": "pphhyy_Barbarian_RustedSword",
+  "ItemType": "ThingDef",
+  "ItemTypeNamespace": "Verse",
+  "OffX": 0.3055455,
+  "OffY": -0.0280604213,
+  "BladeStart": 0.136404127,
+  "BladeEnd": 0.7724381,
+  "MeleeWeaponType": 54
+}

--- a/WeaponTweakData/projectjedi.factions.txt
+++ b/WeaponTweakData/projectjedi.factions.txt
@@ -1,0 +1,1 @@
+Star Wars - Factions

--- a/WeaponTweakData/rh2.faction.militaires.sans.frontieres.txt
+++ b/WeaponTweakData/rh2.faction.militaires.sans.frontieres.txt
@@ -1,0 +1,1 @@
+[RH2] Faction: Militaires Sans Frontieres

--- a/WeaponTweakData/sarg.alphamemes.txt
+++ b/WeaponTweakData/sarg.alphamemes.txt
@@ -1,0 +1,1 @@
+Alpha Memes

--- a/WeaponTweakData/xmb.breadmech.txt
+++ b/WeaponTweakData/xmb.breadmech.txt
@@ -1,0 +1,1 @@
+ExGT Bio Mechanoid


### PR DESCRIPTION
 - Automatic missing patch reporting feature now rejects requests when the requester is not using the latest version of Melee Animation.
 - Idle animations now inherit pawn draw matrix by default, can be changed in settings under General tab.
   - This improves compatibility with mods like Yayo's animation, and mods that change pawn size to be larger or smaller.
 - Added support for several more mods.