### PR TITLE
Configures release changelog tag sorting

### DIFF
--- a/.github/workflows/GenerateReleaseZip.yml
+++ b/.github/workflows/GenerateReleaseZip.yml
@@ -136,6 +136,13 @@ jobs:
     - name: Build Changelog
       id: github_release
       uses: mikepenz/release-changelog-builder-action@v5
+      with:
+          configurationJson: |
+            {
+              "tag_resolver": {
+                "method": "sort"
+              }
+            }
       env:
         GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
 


### PR DESCRIPTION
Configures the release changelog builder to sort tags instead of using the default "semver" method.